### PR TITLE
#9 update for 1.1.0 schema

### DIFF
--- a/src/main/groovy/org/lappsgrid/metadata/DataSourceMetadata.groovy
+++ b/src/main/groovy/org/lappsgrid/metadata/DataSourceMetadata.groovy
@@ -40,7 +40,7 @@ import org.lappsgrid.serialization.Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder(["schema","name","version","description","vendor","allow","license", "licenseDesc"])
 class DataSourceMetadata {
-    public static final String DEFAULT_SCHEMA_URL = 'http://vocab.lappsgrid.org/schema/datasource-schema-1.0.0.json'
+    public static final String DEFAULT_SCHEMA_URL = 'http://vocab.lappsgrid.org/schema/latest/datasource-schema.json'
 
     /** The JSON-LD schema that defines the metadata layout.  This will be provided
      * automatically by the framework, but can be overridden if needed.

--- a/src/main/groovy/org/lappsgrid/metadata/DataSourceMetadata.groovy
+++ b/src/main/groovy/org/lappsgrid/metadata/DataSourceMetadata.groovy
@@ -40,7 +40,7 @@ import org.lappsgrid.serialization.Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder(["schema","name","version","description","vendor","allow","license", "licenseDesc"])
 class DataSourceMetadata {
-    public static final String DEFAULT_SCHEMA_URL = 'http://vocab.lappsgrid.org/schema/latest/datasource-schema.json'
+    public static final String DEFAULT_SCHEMA_URL = 'http://vocab.lappsgrid.org/schema/datasource-schema-1.0.0.json'
 
     /** The JSON-LD schema that defines the metadata layout.  This will be provided
      * automatically by the framework, but can be overridden if needed.

--- a/src/main/groovy/org/lappsgrid/metadata/DataSourceMetadata.groovy
+++ b/src/main/groovy/org/lappsgrid/metadata/DataSourceMetadata.groovy
@@ -38,7 +38,7 @@ import org.lappsgrid.serialization.Data
  */
 @CompileStatic
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder(["schema","name","version","description","vendor","allow","license"])
+@JsonPropertyOrder(["schema","name","version","description","vendor","allow","license", "licenseDesc"])
 class DataSourceMetadata {
     public static final String DEFAULT_SCHEMA_URL = 'http://vocab.lappsgrid.org/schema/datasource-schema-1.0.0.json'
 
@@ -73,6 +73,9 @@ class DataSourceMetadata {
      */
     String license
 
+    /** * The license of the wrapped tool, if any, in restructuredtext markup format */
+    String licenseDesc
+
     /** Languages available from the data source. */
     List<String> language
 
@@ -98,6 +101,7 @@ class DataSourceMetadata {
         this.description = map.description
         this.allow = map.allow
         this.license = map.license
+        this.licenseDesc = map.licenseDesc
         this.language = (List) map.language
         this.format = (List) map.format
         this.encoding = map.encoding

--- a/src/main/groovy/org/lappsgrid/metadata/DataSourceMetadataBuilder.groovy
+++ b/src/main/groovy/org/lappsgrid/metadata/DataSourceMetadataBuilder.groovy
@@ -60,6 +60,11 @@ class DataSourceMetadataBuilder {
         return this
     }
 
+    DataSourceMetadataBuilder licenseDesc(String description) {
+        metadata.licenseDesc = description
+        return this
+    }
+
     DataSourceMetadataBuilder language(String language) {
         metadata.addLanguage(language)
         return this

--- a/src/main/groovy/org/lappsgrid/metadata/IOSpecification.groovy
+++ b/src/main/groovy/org/lappsgrid/metadata/IOSpecification.groovy
@@ -48,6 +48,10 @@ public class IOSpecification {
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     List<String> annotations = []
 
+    /** A map from annotation type URIs to tagset type URIs if a tagset is specified for the annotation */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    Map<String, String> tagSets = [:]
+
     public IOSpecification() {}
 
     public IOSpecification(Map map) {
@@ -77,6 +81,10 @@ public class IOSpecification {
 
     void addAnnotations(String[] annotation) {
         annotations.addAll(Arrays.asList(annotation))
+    }
+
+    void addTagSet(String annType, String tagSetType) {
+        tagSets.put(annType, tagSetType)
     }
 
 //    void add(ContentType type) {

--- a/src/main/groovy/org/lappsgrid/metadata/ServiceMetadata.groovy
+++ b/src/main/groovy/org/lappsgrid/metadata/ServiceMetadata.groovy
@@ -40,7 +40,7 @@ import org.lappsgrid.serialization.Data
 @JsonPropertyOrder(["schema","name","version","description","vendor","allow","license", "licenseDesc","url", "parameters", "requires", "produces"])
 class  ServiceMetadata {
 
-    public static final String DEFAULT_SCHEMA_URL = 'http://vocab.lappsgrid.org/schema/latest/metadata-schema.json'
+    public static final String DEFAULT_SCHEMA_URL = 'http://vocab.lappsgrid.org/schema/service-schema-1.0.0.json'
 
     /** The JSON schema that describes the JSON format. */
     @JsonProperty('$schema')

--- a/src/main/groovy/org/lappsgrid/metadata/ServiceMetadata.groovy
+++ b/src/main/groovy/org/lappsgrid/metadata/ServiceMetadata.groovy
@@ -37,7 +37,7 @@ import org.lappsgrid.serialization.Data
  */
 @CompileStatic
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder(["schema","name","version","description","vendor","allow","license","url", "parameters", "requires", "produces"])
+@JsonPropertyOrder(["schema","name","version","description","vendor","allow","license", "licenseDesc","url", "parameters", "requires", "produces"])
 class  ServiceMetadata {
 
     public static final String DEFAULT_SCHEMA_URL = 'http://vocab.lappsgrid.org/schema/service-schema-1.0.0.json'
@@ -77,6 +77,11 @@ class  ServiceMetadata {
      * The license for this service.
      */
     String license
+
+    /**
+     * The license of the wrapped tool, if any, in restructuredtext markup format
+     */
+    String licenseDesc
 
     /**
      * The full URL used to invoke the service.
@@ -128,6 +133,7 @@ class  ServiceMetadata {
         this.description = map.description
         this.allow = map.allow
         this.license = map.license
+        this.licenseDesc = map.licenseDesc
         this.url = map.url
         this.parameters = (List) map.parameters
         this.requires = new IOSpecification((Map)map.requires)

--- a/src/main/groovy/org/lappsgrid/metadata/ServiceMetadata.groovy
+++ b/src/main/groovy/org/lappsgrid/metadata/ServiceMetadata.groovy
@@ -40,7 +40,7 @@ import org.lappsgrid.serialization.Data
 @JsonPropertyOrder(["schema","name","version","description","vendor","allow","license", "licenseDesc","url", "parameters", "requires", "produces"])
 class  ServiceMetadata {
 
-    public static final String DEFAULT_SCHEMA_URL = 'http://vocab.lappsgrid.org/schema/service-schema-1.0.0.json'
+    public static final String DEFAULT_SCHEMA_URL = 'http://vocab.lappsgrid.org/schema/latest/metadata-schema.json'
 
     /** The JSON schema that describes the JSON format. */
     @JsonProperty('$schema')

--- a/src/main/groovy/org/lappsgrid/metadata/ServiceMetadataBuilder.groovy
+++ b/src/main/groovy/org/lappsgrid/metadata/ServiceMetadataBuilder.groovy
@@ -71,6 +71,10 @@ class ServiceMetadataBuilder {
         metadata.license = license
         return this
     }
+    ServiceMetadataBuilder licenseDesc(String description) {
+        metadata.licenseDesc = description
+        return this
+    }
 
     ServiceMetadataBuilder produce(String type) {
         metadata.produces.addAnnotation(type)

--- a/src/test/groovy/org/lappsgrid/metadata/IOSpecificationTest.groovy
+++ b/src/test/groovy/org/lappsgrid/metadata/IOSpecificationTest.groovy
@@ -88,6 +88,15 @@ class IOSpecificationTest {
         assertTrue "ascii" == spec.format[1]
     }
 
+    @Test
+    void testTagSet() {
+        IOSpecification spec = newSpec(TEXT, TOKEN);
+        spec.addTagSet(TOKEN, "upenn")
+        assertEquals(spec.tagSets.size(), 1)
+        assertEquals(spec.tagSets.containsKey(TOKEN), true)
+        assertEquals(spec.tagSets.get(TOKEN), "upenn")
+    }
+
     IOSpecification newSpec(String encoding, String language, String contentType, String annotationType) {
         IOSpecification spec = new IOSpecification()
         spec.encoding = encoding


### PR DESCRIPTION
Starting a PR just with adding the `licenseDesc` field. Adding `tagSet` is also mentioned in #9, but I'm not sure how it should be added. 
For example, when a tool "produces" `TOKEN` and `DEPENDENCY_STR`, it would be having two `tagSet` for each annotation type. Should metadata list them in random order, or do we want some sort of mapping between annotation types and their tagsets? 